### PR TITLE
Add idField and a transform function.

### DIFF
--- a/model.js
+++ b/model.js
@@ -1,5 +1,6 @@
 'use strict';
 // Cache configured time or 1 hour
+const farmhash = require("farmhash")
 const config = require('config');
 const ttl = (config.craigslist && config.craigslist.ttl) || 60 * 60;
 const request = require('request').defaults({ gzip: true });
@@ -16,7 +17,8 @@ module.exports = function() {
       apartments.ttl = ttl;
       apartments.metadata = {
         name: `${city} ${type}`,
-        description: `Craigslist ${type} listings proxied by https://github.com/dmfenton/koop-provider-craigslist`
+        description: `Craigslist ${type} listings proxied by https://github.com/dmfenton/koop-provider-craigslist`,
+        idField: 'featureId' // Informs FeatureServer and Winnow to use this field as an OBJECTID, should be unique integer <= 2147483647 
       };
       callback(null, apartments);
     });
@@ -54,7 +56,8 @@ function formatFeature(apt) {
       bedrooms: parseFloat(apt.Bedrooms),
       postDate: dateFormat(apt.PostedDate),
       posting: apt.PostingURL,
-      thumbnail: apt.ImageThumb
+      thumbnail: apt.ImageThumb,
+      featureId: transformId(apt.PostingID) // Transform the PostingID to an integer <= 2147483647
     }
   };
   if (!isNaN(feature.properties.price) && !isNaN(feature.properties.bedrooms)) {
@@ -66,4 +69,18 @@ function formatFeature(apt) {
 
 function dateFormat(date) {
   return new Date(parseInt(date, 10) * 1000).toISOString();
+}
+
+/**
+ * Create an ID that is an integer in range of 0 - 2147483647. Should be noted that
+ * the scaling of unsigned 32-bit integers to a range of 0 - 2147483647 increases likely hood
+ * that two different input receive the same output
+ * @param {*} id 
+ */
+function transformId (id) {
+    // Hash to 32 bit unsigned integer
+    const hash = farmhash.hash32(id.toString());
+    
+    // Normalize to range of postive values of signed integer
+    return Math.round((hash / 4294967295) * (2147483647))
 }


### PR DESCRIPTION
Adding this so we have an example of Koop provider setting an idField, as well as a method for creating  numeric integer ids < 2147483647, if the data doesn't currently include them.