### PR TITLE
Add support for securing services with access token

### DIFF
--- a/controller/auth.js
+++ b/controller/auth.js
@@ -1,0 +1,22 @@
+const jwt = require('jsonwebtoken');
+const ACCESS_TOKEN_SECRET = process.env.ACCESS_TOKEN_SECRET
+
+module.exports = { tokenValidator }
+
+function tokenValidator(req, res, next) {
+  const tokenResponse = { 
+    "error": {
+      "code": 499,
+      "message": "Token Required",
+      "details": []
+    }
+  }
+  if (req.query.token === undefined) return res.status(200).json(tokenResponse)
+
+  jwt.verify(req.query.token, ACCESS_TOKEN_SECRET, function(err, decoded) {
+    if (err) return res.status(200).json(tokenResponse)
+    next()
+  });
+
+  next()
+}

--- a/controller/index.js
+++ b/controller/index.js
@@ -1,94 +1,50 @@
 const jwt = require('jsonwebtoken');
-const AUTH_TOKEN_SECRET = process.env.AUTH_TOKEN_SECRET
 const ACCESS_TOKEN_SECRET = process.env.ACCESS_TOKEN_SECRET
 const TOKEN_ISSUER = process.env.TOKEN_ISSUER
+const USERNAME = process.env.USERNAME || 'dummy'
+const PASSWORD = process.env.PASSWORD || 'password'
 
 module.exports = function (model) {
   this.model = model
 
-  this.generateToken = function (req, res) {
-
-    if (req.query.hasOwnProperty('token')) return accessToken(req, res)
-
-    return authorizationGrant(req, res)
-  }
-
+  /**
+   * create the authInfo object with Url specific to context of deployment
+   * @param {*} req 
+   */
   this.generateAuthInfo = function(req){
     return {
       metadata: {
         authInfo: {
           isTokenBasedSecurity: true,
-          tokenServicesUrl: `${req.protocol}://${req.headers.host}/auth-server/generateToken`
+          tokenServicesUrl: `${req.protocol}://${req.headers.host}/craigslist/auth-server/generateToken`
         }
       }
     }
   }
-}
 
-function authorizationGrant (req, res) {
-
-
-    // req.query
-    // {
-    //   request: "getToken",
-    //   username: "username",
-    //   password: "password",
-    //   expiration: 60
-    //   referer: "www.arcgis.com"
-    //   f: "json"
-    // }
-
-    // take username and password and authenticate
-
-    let expires = Date.now() + (60 * 60 * 1000)
-    // Generate token
-    const token = jwt.sign({
-      exp: Math.floor(expires / 1000),
-      iss: TOKEN_ISSUER,
-      sub: req.query.username
-    }, AUTH_TOKEN_SECRET);
-
-    // Generate Token Guts
-
-    // generate authorization token
-    // send back authorization payload
-    let json = {
-      token,
-      expires
-     }
-
-    res.status(200).json(json)
-}
-
-function accessToken (req, res) {
-
-  const tokenResponse = { 
-    "error": {
-      "code": 499,
-      "message": "Token Required",
-      "details": []
+  /**
+   * Generate an access token if credentials pass authentication
+   * @param {*} req 
+   * @param {*} res 
+   */
+  this.generateToken = function (req, res) {
+    // Temporary identity management
+    if(req.query.username !== USERNAME || req.query.password !== PASSWORD) {
+      res.status(200).json({
+        'error' :{
+          'code' : 400,
+          'message' : 'Unable to generate token.',
+          'details':['Invalid username or password.']
+        }
+      });
     }
-  }
-  if (req.query.token === undefined) return res.status(200).json(tokenResponse)
 
-  jwt.verify(req.query.token, AUTH_TOKEN_SECRET, function(err, decoded) {
-    if (err) return res.status(200).json(tokenResponse)
-
-    let expires = Date.now() + (60 * 60 * 1000)
-
-    const token = jwt.sign({
-      exp: Math.floor(expires / 1000),
-      iss: TOKEN_ISSUER,
-      sub: req.query.username
-    }, ACCESS_TOKEN_SECRET);
-  
+    // Create access token
+    let expires = Date.now() + (3 * 60 * 1000)
     let json = {
-      token,
+      token: jwt.sign({ exp: Math.floor(expires / 1000),iss: TOKEN_ISSUER, sub: req.query.username}, ACCESS_TOKEN_SECRET),
       expires
-     }
-  
+    }
     res.status(200).json(json)
-  });
-
-
+  }
 }

--- a/controller/index.js
+++ b/controller/index.js
@@ -40,7 +40,7 @@ module.exports = function (model) {
     }
 
     // Create access token
-    let expires = Date.now() + (3 * 60 * 1000)
+    let expires = Date.now() + (60 * 60 * 1000)
     let json = {
       token: jwt.sign({ exp: Math.floor(expires / 1000),iss: TOKEN_ISSUER, sub: req.query.username}, ACCESS_TOKEN_SECRET),
       expires

--- a/controller/index.js
+++ b/controller/index.js
@@ -1,0 +1,94 @@
+const jwt = require('jsonwebtoken');
+const AUTH_TOKEN_SECRET = process.env.AUTH_TOKEN_SECRET
+const ACCESS_TOKEN_SECRET = process.env.ACCESS_TOKEN_SECRET
+const TOKEN_ISSUER = process.env.TOKEN_ISSUER
+
+module.exports = function (model) {
+  this.model = model
+
+  this.generateToken = function (req, res) {
+
+    if (req.query.hasOwnProperty('token')) return accessToken(req, res)
+
+    return authorizationGrant(req, res)
+  }
+
+  this.generateAuthInfo = function(req){
+    return {
+      metadata: {
+        authInfo: {
+          isTokenBasedSecurity: true,
+          tokenServicesUrl: `${req.protocol}://${req.headers.host}/auth-server/generateToken`
+        }
+      }
+    }
+  }
+}
+
+function authorizationGrant (req, res) {
+
+
+    // req.query
+    // {
+    //   request: "getToken",
+    //   username: "username",
+    //   password: "password",
+    //   expiration: 60
+    //   referer: "www.arcgis.com"
+    //   f: "json"
+    // }
+
+    // take username and password and authenticate
+
+    let expires = Date.now() + (60 * 60 * 1000)
+    // Generate token
+    const token = jwt.sign({
+      exp: Math.floor(expires / 1000),
+      iss: TOKEN_ISSUER,
+      sub: req.query.username
+    }, AUTH_TOKEN_SECRET);
+
+    // Generate Token Guts
+
+    // generate authorization token
+    // send back authorization payload
+    let json = {
+      token,
+      expires
+     }
+
+    res.status(200).json(json)
+}
+
+function accessToken (req, res) {
+
+  const tokenResponse = { 
+    "error": {
+      "code": 499,
+      "message": "Token Required",
+      "details": []
+    }
+  }
+  if (req.query.token === undefined) return res.status(200).json(tokenResponse)
+
+  jwt.verify(req.query.token, AUTH_TOKEN_SECRET, function(err, decoded) {
+    if (err) return res.status(200).json(tokenResponse)
+
+    let expires = Date.now() + (60 * 60 * 1000)
+
+    const token = jwt.sign({
+      exp: Math.floor(expires / 1000),
+      iss: TOKEN_ISSUER,
+      sub: req.query.username
+    }, ACCESS_TOKEN_SECRET);
+  
+    let json = {
+      token,
+      expires
+     }
+  
+    res.status(200).json(json)
+  });
+
+
+}

--- a/identity-store/index.js
+++ b/identity-store/index.js
@@ -1,0 +1,34 @@
+const userStore = require('./user-store.json')
+
+// 
+/**
+ * Validate username and password. Replace the contents of this function to fit
+ * your choice of identity store. This example made asynchronous with promise/callback
+ * because most identity stores (DB or third-party call), will be async and require
+ * promise or callback
+ * @param {string} username 
+ * @param {string} password 
+ * @param {function} callback (optional) function to execute after completing credential validation
+ */
+function validateCredentials(username, password, callback) {
+  const promise = new Promise((resolve, reject) => {
+    process.nextTick(function() {
+      const user = userStore.find(user => {
+        return user.username === username
+      })
+
+      if(!user || user.password !== password) {
+        resolve(false)
+      }
+      resolve(true);
+    })
+  })
+
+  if (callback && typeof callback == 'function') {
+    promise.then(callback.bind(null, null), callback);
+  }
+
+  return promise;
+}
+
+module.exports = { validateCredentials }

--- a/identity-store/user-store.json
+++ b/identity-store/user-store.json
@@ -1,0 +1,6 @@
+[
+  {
+    "username": "dread-pirate",
+    "password": "roberts"
+  }
+]

--- a/index.js
+++ b/index.js
@@ -5,5 +5,8 @@ module.exports = {
   hosts: true,
   Model: require('./model'),
   version: pkg.version,
-  type: 'provider'
+  type: 'provider',
+  routes: require('./routes'), // Optional, any additional routes that should be handled by this provider
+  Controller: require('./controller'), // Optional, a controller to support unique routes,
+  auth: require('./controller/auth')
 }

--- a/index.js
+++ b/index.js
@@ -8,5 +8,5 @@ module.exports = {
   type: 'provider',
   routes: require('./routes'), // Optional, any additional routes that should be handled by this provider
   Controller: require('./controller'), // Optional, a controller to support unique routes,
-  auth: require('./controller/auth')
+  middleware: require('./middleware')
 }

--- a/index.js
+++ b/index.js
@@ -1,7 +1,9 @@
 // the name of provider is used by koop to help build default routes for FeatureService and a preview
 const pkg = require('./package.json')
+const namespace = require('./namespace')
+
 module.exports = {
-  name: 'craigslist',
+  name: namespace,
   hosts: true,
   Model: require('./model'),
   version: pkg.version,

--- a/middleware/index.js
+++ b/middleware/index.js
@@ -2,24 +2,39 @@ const jwt = require('jsonwebtoken')
 const unless = require('express-unless')
 const ACCESS_TOKEN_SECRET = process.env.ACCESS_TOKEN_SECRET
 
-const tokenValidator = function(req, res, next) {
-  console.log('token-middleware')
-  const tokenResponse = { 
-    "error": {
-      "code": 499,
-      "message": "Token Required",
-      "details": []
-    }
-  }
-  if (req.query.token === undefined) return res.status(200).json(tokenResponse)
+/**
+*
+*/
+function tokenValidator (providerName) {
+  
+  // Define validation function
+  let validationFunc = function(req, res, next) {
 
-  jwt.verify(req.query.token, ACCESS_TOKEN_SECRET, function(err, decoded) {
-    if (err) next(err)
-    next()
+    // Verify token
+    jwt.verify(req.query.token, ACCESS_TOKEN_SECRET, function(err, decoded) {
+      // Respond with success, but send 499 error object (AGOL spec)
+      if (err) return res.status(200).json({ 
+        "error": {
+          "code": 499,
+          "message": "Token Required",
+          "details": []
+        }
+      }) 
+      // Otherwise, move on to next middleware
+      return next()
+    });
+  }
+
+  // Add "unless" to validation function to exclude specific routes from getting this middleware
+  validationFunc.unless = unless
+  return validationFunc.unless({
+    path: [
+      {url: `/${providerName}/rest/info`, methods: ['GET', 'POST']},
+      {url: `/${providerName}/generateToken`, methods: ['GET', 'POST']}
+    ]
   });
 }
 
-tokenValidator.unless = unless;
 
 module.exports = { tokenValidator }
 

--- a/middleware/index.js
+++ b/middleware/index.js
@@ -1,9 +1,9 @@
-const jwt = require('jsonwebtoken');
+const jwt = require('jsonwebtoken')
+const unless = require('express-unless')
 const ACCESS_TOKEN_SECRET = process.env.ACCESS_TOKEN_SECRET
 
-module.exports = { tokenValidator }
-
-function tokenValidator(req, res, next) {
+const tokenValidator = function(req, res, next) {
+  console.log('token-middleware')
   const tokenResponse = { 
     "error": {
       "code": 499,
@@ -14,9 +14,12 @@ function tokenValidator(req, res, next) {
   if (req.query.token === undefined) return res.status(200).json(tokenResponse)
 
   jwt.verify(req.query.token, ACCESS_TOKEN_SECRET, function(err, decoded) {
-    if (err) return res.status(200).json(tokenResponse)
+    if (err) next(err)
     next()
   });
-
-  next()
 }
+
+tokenValidator.unless = unless;
+
+module.exports = { tokenValidator }
+

--- a/namespace.js
+++ b/namespace.js
@@ -1,0 +1,1 @@
+module.exports = 'craigslist'

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "config": "^1.25.1",
+    "express-unless": "^0.5.0",
     "jsonwebtoken": "^8.2.1",
     "koop": "^3.4.0",
     "request": "^2.72.0"

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "config": "^1.25.1",
+    "jsonwebtoken": "^8.2.1",
     "koop": "^3.4.0",
     "request": "^2.72.0"
   },

--- a/routes/index.js
+++ b/routes/index.js
@@ -1,7 +1,7 @@
 module.exports = [
   {
-      path: '/auth-server/generateToken',
-      methods: ['get'],
+      path: '/craigslist/auth-server/generateToken',
+      methods: ['get', 'post'],
       handler: 'generateToken'
     }
   ]

--- a/routes/index.js
+++ b/routes/index.js
@@ -1,7 +1,9 @@
+const namespace = require('../namespace')
+
 module.exports = [
   {
-      path: '/craigslist/auth-server/generateToken',
-      methods: ['get', 'post'],
-      handler: 'generateToken'
-    }
-  ]
+    path: `/${namespace}/generateToken`,
+    methods: ['get', 'post'],
+    handler: 'generateToken'
+  }
+]

--- a/routes/index.js
+++ b/routes/index.js
@@ -1,0 +1,7 @@
+module.exports = [
+  {
+      path: '/auth-server/generateToken',
+      methods: ['get'],
+      handler: 'generateToken'
+    }
+  ]


### PR DESCRIPTION
* Added `authInfo` controller used by koop-output-geoservices to generate provider specific authentication info for the provider's `rest/info` service

* Added custom route and controller `generateToken` that checks submitted username and password and generates an access token

* Added simple identity-store with API for validating credentials.

* Added `middleware` property to provider definition that exposes handlers in the `middleware/index.js` module.  This allows provider middleware to be applied after route registration.

* Added a `tokenValidator` middleware that checks all requests (except `craigslist/rest/info` and `craigslist/generateToken`) for a valid access-token.  Requests with missing or invalid tokens are prevented from continuing.
